### PR TITLE
feat: implément player app

### DIFF
--- a/starter-code/quiz-app/host-app/src/App.css
+++ b/starter-code/quiz-app/host-app/src/App.css
@@ -91,6 +91,12 @@ body {
   color: #f1f5f9;
 }
 
+.connection-hint {
+  color: #f59e0b;
+  font-size: 0.95rem;
+  margin-bottom: 1rem;
+}
+
 /* --- Quiz Code Display --- */
 .quiz-code {
   font-size: 4rem;
@@ -170,6 +176,24 @@ body {
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
+}
+
+.ended-screen .ended-message {
+  font-size: 1.1rem;
+  color: #94a3b8;
+  margin-bottom: 1.5rem;
+}
+
+.ended-actions {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.ended-actions .btn-primary {
+  min-width: 280px;
 }
 
 .btn-start {

--- a/starter-code/quiz-app/host-app/src/App.tsx
+++ b/starter-code/quiz-app/host-app/src/App.tsx
@@ -98,6 +98,10 @@ function App() {
 
   /** Appele quand le host soumet le formulaire de creation */
   const handleCreateQuiz = (title: string, questions: QuizQuestion[]) => {
+    if (status !== 'connected') {
+      alert('Connexion au serveur perdue. Démarrez le serveur sur le port 3001.')
+      return
+    }
     sendMessage({
       type: 'host:create',
       title,
@@ -119,7 +123,12 @@ function App() {
   const renderPhase = () => {
     switch (phase) {
       case 'create':
-        return <CreateQuiz onSubmit={handleCreateQuiz} />
+        return (
+          <CreateQuiz
+            onSubmit={handleCreateQuiz}
+            isConnected={status === 'connected'}
+          />
+        )
 
       case 'lobby':
         return (
@@ -157,11 +166,14 @@ function App() {
 
       case 'ended':
         return (
-          <div className="phase-container">
+          <div className="phase-container ended-screen">
             <h1>Quiz termine !</h1>
-            <button className="btn-primary" onClick={() => setPhase('create')}>
-              Creer un nouveau quiz
-            </button>
+            <p className="ended-message">Merci d'avoir anime ce quiz.</p>
+            <div className="ended-actions">
+              <button className="btn-primary" onClick={() => setPhase('create')}>
+                Retour a l'accueil — Creer un nouveau quiz
+              </button>
+            </div>
           </div>
         )
 

--- a/starter-code/quiz-app/host-app/src/components/CreateQuiz.tsx
+++ b/starter-code/quiz-app/host-app/src/components/CreateQuiz.tsx
@@ -9,6 +9,8 @@ import type { QuizQuestion } from '@quiz/shared-types'
 interface CreateQuizProps {
   /** Callback appele quand le formulaire est soumis */
   onSubmit: (title: string, questions: QuizQuestion[]) => void
+  /** Si false, le bouton est desactive (serveur non connecte) */
+  isConnected?: boolean
 }
 
 /**
@@ -32,7 +34,7 @@ interface CreateQuizProps {
  * .question-card-header, .choices-inputs, .choice-input-group,
  * .btn-add-question, .btn-remove, .btn-primary
  */
-function CreateQuiz({ onSubmit }: CreateQuizProps) {
+function CreateQuiz({ onSubmit, isConnected = true }: CreateQuizProps) {
   // TODO: State pour le titre
   // TODO: State pour la liste des questions
   const [title, setTitle] = useState('')
@@ -70,6 +72,16 @@ function CreateQuiz({ onSubmit }: CreateQuizProps) {
     setQuestions(questions.filter(q => q.id !== id))
   }
 
+  const isFormComplete =
+    title.trim() !== '' &&
+    questions.length > 0 &&
+    questions.every(
+      (q) =>
+        q.text.trim() !== '' &&
+        q.choices.every((c) => c.trim() !== '') &&
+        q.choices[q.correctIndex]?.trim() !== ''
+    )
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     // TODO: Valider que le titre n'est pas vide
@@ -104,6 +116,11 @@ function CreateQuiz({ onSubmit }: CreateQuizProps) {
   return (
     <div className="phase-container">
       <h1>Creer un Quiz</h1>
+      {!isConnected && (
+        <p className="connection-hint">
+          Démarrez le serveur (port 3001) pour créer un quiz.
+        </p>
+      )}
       <form className="create-form" onSubmit={handleSubmit}>
         {/* Titre */}
         <div className="form-group">
@@ -194,7 +211,12 @@ function CreateQuiz({ onSubmit }: CreateQuizProps) {
           >
             + Ajouter une question
           </button>
-          <button type="submit" className="btn-primary">
+          <button
+            type="submit"
+            className="btn-primary"
+            disabled={!isConnected || !isFormComplete}
+            title={!isFormComplete ? 'Remplissez le titre et toutes les questions (texte + 4 choix)' : undefined}
+          >
             Créer le Quiz
           </button>
         </div>

--- a/starter-code/quiz-app/player-app/src/App.css
+++ b/starter-code/quiz-app/player-app/src/App.css
@@ -418,10 +418,22 @@ body {
 }
 
 /* --- Ended Screen --- */
-.ended-message {
+.ended-screen .ended-message {
   font-size: 1.1rem;
   color: #94a3b8;
   margin-bottom: 1.5rem;
+}
+
+.ended-actions {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.ended-actions .btn-primary {
+  min-width: 280px;
 }
 
 /* --- Responsive --- */

--- a/starter-code/quiz-app/player-app/src/App.tsx
+++ b/starter-code/quiz-app/player-app/src/App.tsx
@@ -3,7 +3,7 @@
 // A IMPLEMENTER : gestion des messages et routage par phase
 // ============================================================
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useWebSocket } from './hooks/useWebSocket'
 import type { QuizPhase, QuizQuestion } from '@quiz/shared-types'
 import JoinScreen from './components/JoinScreen'
@@ -28,57 +28,61 @@ function App() {
   const [score, setScore] = useState(0)
   const [rankings, setRankings] = useState<{ name: string; score: number }[]>([])
   const [error, setError] = useState<string | undefined>(undefined)
+  const [lastChoiceIndex, setLastChoiceIndex] = useState<number>(-1)
+  const lastChoiceIndexRef = useRef<number>(-1)
+  const pendingChoiceRef = useRef<number | null>(null)
 
   // --- Traitement des messages du serveur ---
   useEffect(() => {
     if (!lastMessage) return
 
-    // TODO: Traiter chaque type de message du serveur
-    // Utiliser un switch sur lastMessage.type
-
     switch (lastMessage.type) {
       case 'joined': {
-        // TODO: Mettre a jour la liste des joueurs
-        // TODO: Passer en phase 'lobby'
-        // TODO: Effacer les erreurs
+        setPlayers(lastMessage.players)
+        setPhase('lobby')
+        setError(undefined)
         break
       }
 
       case 'question': {
-        // TODO: Mettre a jour currentQuestion avec lastMessage.question
-        // TODO: Mettre a jour remaining avec lastMessage.question.timerSec
-        // TODO: Reinitialiser hasAnswered a false
-        // TODO: Changer la phase en 'question'
+        setCurrentQuestion(lastMessage.question)
+        setRemaining(lastMessage.question.timerSec)
+        setHasAnswered(false)
+        setLastChoiceIndex(-1)
+        lastChoiceIndexRef.current = -1
+        pendingChoiceRef.current = null
+        setPhase('question')
         break
       }
 
       case 'tick': {
-        // TODO: Mettre a jour remaining avec lastMessage.remaining
+        setRemaining(lastMessage.remaining)
         break
       }
 
       case 'results': {
-        // TODO: Verifier si le joueur a repondu correctement
-        //   (comparer la reponse du joueur avec lastMessage.correctIndex)
-        // TODO: Mettre a jour lastCorrect (true/false)
-        // TODO: Recuperer le score du joueur depuis lastMessage.scores
-        // TODO: Changer la phase en 'feedback'
+        const choiceSent = pendingChoiceRef.current ?? lastChoiceIndexRef.current
+        const correctIndex = Number(lastMessage.correctIndex)
+        setLastCorrect(Number(choiceSent) === correctIndex)
+        setScore((prev) => lastMessage.scores[playerName] ?? prev)
+        setPhase('feedback')
+        pendingChoiceRef.current = null
         break
       }
 
       case 'leaderboard': {
-        // TODO: Mettre a jour rankings avec lastMessage.rankings
-        // TODO: Changer la phase en 'leaderboard'
+        setRankings(lastMessage.rankings)
+        setPhase('leaderboard')
         break
       }
 
       case 'ended': {
-        // TODO: Changer la phase en 'ended'
+        setPhase('ended')
         break
       }
 
       case 'error': {
-        // TODO: Stocker le message d'erreur dans le state error
+        setError(lastMessage.message)
         break
       }
     }
@@ -86,17 +90,20 @@ function App() {
 
   // --- Handlers ---
 
-  /** Appele quand le joueur soumet le formulaire de connexion */
   const handleJoin = (code: string, name: string) => {
-    // TODO: Sauvegarder le nom du joueur dans playerName
-    // TODO: Envoyer un message 'join' au serveur avec sendMessage
+    setPlayerName(name)
+    setError(undefined)
+    sendMessage({ type: 'join', quizCode: code.toUpperCase().trim(), name: name.trim() })
   }
 
-  /** Appele quand le joueur clique sur un choix de reponse */
   const handleAnswer = (choiceIndex: number) => {
-    // TODO: Verifier que le joueur n'a pas deja repondu (hasAnswered)
-    // TODO: Marquer hasAnswered a true
-    // TODO: Envoyer un message 'answer' au serveur avec l'id de la question et le choiceIndex
+    if (hasAnswered || !currentQuestion) return
+    const index = Number(choiceIndex)
+    lastChoiceIndexRef.current = index
+    pendingChoiceRef.current = index
+    setHasAnswered(true)
+    setLastChoiceIndex(index)
+    sendMessage({ type: 'answer', questionId: currentQuestion.id, choiceIndex: index })
   }
 
   // --- Rendu par phase ---
@@ -130,12 +137,14 @@ function App() {
 
       case 'ended':
         return (
-          <div className="phase-container">
+          <div className="phase-container ended-screen">
             <h1>Quiz termine !</h1>
             <p className="ended-message">Merci d'avoir participe !</p>
-            <button className="btn-primary" onClick={() => setPhase('join')}>
-              Rejoindre un autre quiz
-            </button>
+            <div className="ended-actions">
+              <button className="btn-primary" onClick={() => setPhase('join')}>
+                Retour a l'accueil — Rejoindre un autre quiz
+              </button>
+            </div>
           </div>
         )
 

--- a/starter-code/quiz-app/player-app/src/components/AnswerScreen.tsx
+++ b/starter-code/quiz-app/player-app/src/components/AnswerScreen.tsx
@@ -34,19 +34,34 @@ interface AnswerScreenProps {
  * .answer-question, .answer-grid, .answer-btn, .selected, .answered-message
  */
 function AnswerScreen({ question, remaining, onAnswer, hasAnswered }: AnswerScreenProps) {
-  // TODO: State optionnel pour stocker l'index du choix selectionne
+  const [selectedIndex, setSelectedIndex] = useState<number>(-1)
 
   const handleClick = (index: number) => {
-    // TODO: Appeler onAnswer(index)
-    // TODO: Optionnel : sauvegarder l'index selectionne pour le style .selected
+    if (hasAnswered) return
+    setSelectedIndex(index)
+    onAnswer(index)
   }
+
+  const timerClass = `answer-timer ${remaining <= 10 ? 'warning' : ''} ${remaining <= 3 ? 'danger' : ''}`.trim()
 
   return (
     <div className="answer-screen">
-      {/* TODO: Timer avec .answer-timer (+ .warning / .danger selon remaining) */}
-      {/* TODO: Texte de la question avec .answer-question */}
-      {/* TODO: Grille de 4 boutons avec .answer-grid et .answer-btn */}
-      {/* TODO: Message "Reponse envoyee !" si hasAnswered */}
+      <div className={timerClass}>{remaining}s</div>
+      <p className="answer-question">{question.text}</p>
+      <div className="answer-grid">
+        {question.choices.map((choice, index) => (
+          <button
+            key={index}
+            type="button"
+            className={`answer-btn ${selectedIndex === index ? 'selected' : ''}`}
+            onClick={() => handleClick(index)}
+            disabled={hasAnswered}
+          >
+            {choice}
+          </button>
+        ))}
+      </div>
+      {hasAnswered && <p className="answered-message">Réponse envoyée !</p>}
     </div>
   )
 }

--- a/starter-code/quiz-app/player-app/src/components/FeedbackScreen.tsx
+++ b/starter-code/quiz-app/player-app/src/components/FeedbackScreen.tsx
@@ -26,10 +26,13 @@ interface FeedbackScreenProps {
 function FeedbackScreen({ correct, score }: FeedbackScreenProps) {
   return (
     <div className="phase-container feedback-container">
-      {/* TODO: Conteneur .feedback avec .correct ou .incorrect */}
-      {/* TODO: Icone .feedback-icon */}
-      {/* TODO: Texte "Bonne reponse !" ou "Mauvaise reponse" */}
-      {/* TODO: Score "Score : {score} pts" */}
+      <div className={`feedback ${correct ? 'correct' : 'incorrect'}`}>
+        <div className="feedback-icon" />
+        <p className="feedback-text">
+          {correct ? 'Bonne réponse !' : 'Mauvaise réponse'}
+        </p>
+        <p className="feedback-score">Score : {score} pts</p>
+      </div>
     </div>
   )
 }

--- a/starter-code/quiz-app/player-app/src/components/JoinScreen.tsx
+++ b/starter-code/quiz-app/player-app/src/components/JoinScreen.tsx
@@ -27,22 +27,46 @@ interface JoinScreenProps {
  * .error-message, .btn-primary
  */
 function JoinScreen({ onJoin, error }: JoinScreenProps) {
-  // TODO: State pour le code du quiz
-  // TODO: State pour le pseudo
+  const [code, setCode] = useState('')
+  const [name, setName] = useState('')
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    // TODO: Valider que les champs ne sont pas vides
-    // TODO: Appeler onJoin(code.toUpperCase(), name)
+    const trimmedCode = code.trim().toUpperCase()
+    const trimmedName = name.trim()
+    if (!trimmedCode || !trimmedName) return
+    onJoin(trimmedCode, trimmedName)
   }
 
   return (
     <form className="join-form" onSubmit={handleSubmit}>
       <h1>Rejoindre un Quiz</h1>
-      {/* TODO: Afficher l'erreur si elle existe */}
-      {/* TODO: Champ code du quiz avec classe .code-input */}
-      {/* TODO: Champ pseudo */}
-      {/* TODO: Bouton Rejoindre */}
+      {error && <div className="error-message">{error}</div>}
+      <div className="form-group">
+        <label htmlFor="quiz-code">Code du quiz</label>
+        <input
+          id="quiz-code"
+          type="text"
+          className="code-input"
+          value={code}
+          onChange={(e) => setCode(e.target.value.toUpperCase())}
+          placeholder="XXXXXX"
+          maxLength={6}
+        />
+      </div>
+      <div className="form-group">
+        <label htmlFor="player-name">Pseudo</label>
+        <input
+          id="player-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Votre pseudo"
+        />
+      </div>
+      <button type="submit" className="btn-primary">
+        Rejoindre
+      </button>
     </form>
   )
 }

--- a/starter-code/quiz-app/player-app/src/components/ScoreScreen.tsx
+++ b/starter-code/quiz-app/player-app/src/components/ScoreScreen.tsx
@@ -29,11 +29,18 @@ interface ScoreScreenProps {
 function ScoreScreen({ rankings, playerName }: ScoreScreenProps) {
   return (
     <div className="phase-container score-screen">
-      {/* TODO: Titre "Classement" avec .leaderboard-title */}
+      <h1 className="leaderboard-title">Classement</h1>
       <div className="leaderboard">
-        {/* TODO: Pour chaque joueur dans rankings, afficher un .leaderboard-item */}
-        {/* TODO: Ajouter la classe .is-me si ranking.name === playerName */}
-        {/* TODO: Afficher rang, nom et score */}
+        {rankings.map((player, index) => (
+          <div
+            key={player.name}
+            className={`leaderboard-item ${player.name === playerName ? 'is-me' : ''}`}
+          >
+            <span className="leaderboard-rank">{index + 1}</span>
+            <span className="leaderboard-name">{player.name}</span>
+            <span className="leaderboard-score">{player.score} pts</span>
+          </div>
+        ))}
       </div>
     </div>
   )

--- a/starter-code/quiz-app/player-app/src/components/WaitingLobby.tsx
+++ b/starter-code/quiz-app/player-app/src/components/WaitingLobby.tsx
@@ -22,9 +22,17 @@ interface WaitingLobbyProps {
 function WaitingLobby({ players }: WaitingLobbyProps) {
   return (
     <div className="phase-container waiting-container">
-      {/* TODO: Message "En attente du host..." avec .waiting-message */}
-      {/* TODO: Nombre de joueurs */}
-      {/* TODO: Liste des joueurs avec .player-list et .player-chip */}
+      <p className="waiting-message">En attente du host...</p>
+      <p className="player-count">
+        {players.length} joueur{players.length > 1 ? 's' : ''} connecté{players.length > 1 ? 's' : ''}
+      </p>
+      <div className="player-list">
+        {players.map((player) => (
+          <div key={player} className="player-chip">
+            {player}
+          </div>
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Troubleshooting
#4

## PR Type
Feature

## Summary
Implementation of **player-app** (5 screens + WebSocket logic) and **host-app** updates (form validation, end screen, return flow). Fix for incorrect “wrong answer” feedback on the player side.

## Description
- **Player-app**: Join, Waiting Lobby, Answer (4 Kahoot-style buttons), Feedback (correct/incorrect + score), Leaderboard; server message handling in `App.tsx`; `handleJoin` / `handleAnswer`; use of `@quiz/shared-types`.
- **Correct/incorrect feedback**: ref for the choice sent + `Number()` comparison with `correctIndex` to avoid false “wrong answer” results.
- **Host-app**: “Create Quiz” button disabled when the form is incomplete or the server is disconnected; message when not connected; end screen with return button.
- **Player-app (end of quiz)**: end screen with “Back to home — Join another quiz” button.

## What's Changed
- [x] Player-app: `App.tsx` (messages, handleJoin, handleAnswer, refs)
- [x] Player-app: JoinScreen, WaitingLobby, AnswerScreen, FeedbackScreen, ScoreScreen
- [x] Player-app: ended screen + styles
- [x] Host-app: CreateQuiz — `isFormComplete`, disabled button + `connection-hint`
- [x] Host-app: ended screen + return button
- [x] Fix player feedback: numeric comparison + ref for choice sent
- [x] Test in real conditions (server + host + 1+ players)

